### PR TITLE
incorporate suggestions by PC and by me

### DIFF
--- a/cfp.md
+++ b/cfp.md
@@ -40,32 +40,29 @@ We appreciate proposals on the following or related topics:
 * presenting & visualizing LOD
 * end-user environments for interaction with LOD (e.g. editing or annotation)
 * crowdsourcing/gamification approaches involving LOD sources
-* applications for open science
+* (other) applications in the context of open science
 
-### Technology (focus on Open Source software)
+### Technology & Tools (focus on Open Source software)
 
-* data transformation/integration/cleansing/enhancement/mapping/interlinking
-* data flow management
-* RDF validation
-* read/write linked data
-* providing updates & syncing data sources
-* machine learning for automatic indexing & named entity recognition
+* data transformation/integration/cleansing/enhancement/mapping/interlinking/validation
+* data flow management, read/write linked data, providing updates & syncing data sources
+* machine learning applications in/for libraries
 * integration of symbolic and subsymbolic approaches
 
 ### Standards & Best Practices
 
-* implementation of FAIR data principles
-* open web standards relevant for libraries
+* implementation of FAIR data principles, interoperability
+* open web standards relevant for libraries, data models, usable APIs
 * application profiles & provenance information
-* working with authorities & knowledge organization systems
-* usable APIs
+* working with controlled vocabularies & knowledge organization systems
 * preservation, maintenance & sustainability
 
 ### Culture
 
-* collaboration, community building and empowerment
+* decentralization, federated structures
 * consolidating open source projects
-* awareness of Western bias, decolonialization
+* collaboration, community building and empowerment
+* diversity sensitivity, equity, inclusion, and accessibility
 
 We are looking forward to receiving your proposals for presentations or
 workshops by **10 April 2023**. Please submit an abstract of 1000–1500

--- a/cfp.md
+++ b/cfp.md
@@ -28,7 +28,7 @@ For this SWIB rendition we will have more interactive formats in order to get
 the most out of participants coming together physically in one place.
 As usual, we will also have presentations and workshops:
 
-* presentations (20 minutes plus 5 q&a)
+* presentations (20 minutes plus 5 minutes Q&A)
 * practical workshops or tutorials (around 2–4 hours including breaks)
 
 We appreciate proposals on the following or related topics:
@@ -38,8 +38,7 @@ We appreciate proposals on the following or related topics:
 * integration of LOD into productive library applications
 * re-use of LOD (from libraries, Wikidata and other sources)
 * presenting & visualizing LOD
-* end-user environments for interaction with LOD (e.g. editing or annotation)
-* crowdsourcing/gamification approaches involving LOD sources
+* graphical user interfaces for interaction with LOD (e.g. editing or annotation)
 * (other) applications in the context of open science
 
 ### Technology & Tools (focus on Open Source software)
@@ -61,7 +60,7 @@ We appreciate proposals on the following or related topics:
 
 * decentralization, federated structures
 * consolidating open source projects
-* collaboration, community building and empowerment
+* collaboration, crowdsourcing, community building and empowerment
 * diversity sensitivity, equity, inclusion, and accessibility
 
 We are looking forward to receiving your proposals for presentations or
@@ -82,12 +81,12 @@ Proposals will be reviewed by the programme committee:
 * Julia Beck (Frankfurt University Library)
 * Uldis Bojars (National Library of Latvia)
 * Nuno Freire (Europeana Foundation, Netherlands)
-* Anna Kasprzik (ZBW, Germany)
-* Huda Khan (Cornell University Library, USA)
+* Anna Kasprzik (ZBW, Germany – Chair)
+* Huda Khan (Stanford University, USA)
 * Niklas Lindström (National Library of Sweden)
 * Devika Madalli (Indian Statistical Institute)
-* Joachim Neubert (ZBW, Germany - Chair)
-* Adrian Pohl (hbz, Germany - Chair)
+* Joachim Neubert (ZBW, Germany)
+* Adrian Pohl (hbz, Germany – Chair)
 * Dorothea Salo (UW-Madison, USA)
 * Jodi Schneider (University of Illinois at Urbana-Champaign, USA)
 * MJ Suhonos (Toronto Metropolitan University, Canada)
@@ -123,10 +122,3 @@ Adrian Pohl\
 hbz\
 Tel. +49-(0)221-40075235\
 E-mail: swib(at)hbz-nrw.de
-
-or 
-
-Joachim Neubert\
-ZBW\
-Tel. +49-(0)40-42834462\
-E-mail: j.neubert(at)zbw.eu


### PR DESCRIPTION
replaced "Western bias, decolonialization" by "diversity sensitivity, equity, inclusion, and accessibility" because the latter subsumes the former? put "usable APIs" with standards
replaced "authorities" with "controlled vocabularies" to refer to previous session name, also added "interoperability" explicitly (after "FAIR principles") and "Tools" in a heading, and "data models" together with "standards" Also summarized three lines under "Technology" that seemed one cluster to me and I changed "applications for open science" to "(other) applications in the context of open science" because it seems to me that all LOD applications ultimatively work towards open science, consciously or unconsciously.